### PR TITLE
Fix broken .zip downloads (enable LFS checkout on build)

### DIFF
--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          lfs: true
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/hugo-deploy.yml
+++ b/.github/workflows/hugo-deploy.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          lfs: true
 
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v3


### PR DESCRIPTION
W treści Lab01 zawarto ZIPa z podstawowymi plikami projektu:

https://github.com/P3-MINI/csharp-site/blob/196b432790c660a939af0c7e9399e8178fd6afaf/content/labs/lab01/index.pl.md?plain=1#L37

Tymczasem obecnie po pobraniu pliku z produkcyjnej wersji strony (https://csharp.mini.pw.edu.pl/labs/lab01/task1-2.zip) otrzymujemy coś takiego (wskaźnik Git Large File Storage):
```console
$ cat task1-2.zip 
version https://git-lfs.github.com/spec/v1
oid sha256:11cadd183924d693e0addf9a1e2ec1bdda8437ac486c7e97f76758d44ddb6f15
size 1991552
```

PR włącza pobieranie plików z LFS przez `actions/checkout@v4` przy budowaniu strony, aby rozwiązać ten problem.